### PR TITLE
traefik supports noop@internal

### DIFF
--- a/templates/traefik/config/routers.yml
+++ b/templates/traefik/config/routers.yml
@@ -6,4 +6,4 @@ http:
       middlewares:
         - "httpsredirect"
       rule: "HostRegexp(`{host:.+}`)"
-      service: "noop"
+      service: "noop@internal"

--- a/templates/traefik/config/services.yml
+++ b/templates/traefik/config/services.yml
@@ -1,8 +1,0 @@
-http:
-  services:
-    noop:
-      loadBalancer:
-        servers:
-          - url: 'http://localhost'
-  
-  


### PR DESCRIPTION
Don't remember this in v2.0, must be new in v2.2 or so...